### PR TITLE
Docker, Skaffold, and Kubernetes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: go
+
+go:
+  - 1.13.x
+
+services:
+  - docker
+
+stages:
+  - lint
+  - vet
+  - deploy
+
+install:
+  - curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64
+  - chmod +x skaffold
+  - mv skaffold /home/travis/bin/
+  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.17.1/bin/linux/amd64/kubectl
+  - chmod +x kubectl
+  - mv kubectl /home/travis/bin/
+  - go get -u github.com/mitchellh/gox
+
+jobs:
+  include:
+    - stage: lint
+      script: make fmt
+    - stage: vet
+      script: make vet
+    - stage: deploy
+      script: make deploy

--- a/build-tools/res/Dockerfile
+++ b/build-tools/res/Dockerfile
@@ -1,0 +1,10 @@
+from golang:1.13-alpine as builder
+copy ${PWD} /bitlybot/
+workdir /bitlybot
+run apk add --no-cache --update make \
+  && go get -u github.com/mitchellh/gox \
+  && make build
+
+from scratch
+copy --from=builder /bitlybot/bin/bitlybot_linux_amd64 .
+entrypoint ["./bitlybot_linux_amd64"]

--- a/build-tools/res/manifest.yaml
+++ b/build-tools/res/manifest.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: deployment
+metadata:
+  name: bitlybot-api
+  labels:
+    app.kubernetes.io/name: bitlybot-api
+    app.kubernetes.io/instance: bitlybot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bitlybot-api
+      app.kubernetes.io/instance: bitlybot
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bitlybot-api
+        app.kubernetes.io/instance: bitlybot
+    spec:
+      containers:
+        - name: bitlybot
+          image: "jharshman/bitlybot"
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+          resources:
+            limits:
+              cpu: 100m
+              memory: 1G
+            requests:
+              cpu: 50m
+              memory: 500Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bitlybot-api
+  labels:
+    app.kubernetes.io/name: bitlybot-api
+    app.kubernetes.io/instance: bitlybot
+spec:
+  type: NodePort
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: bitlybot-api
+    app.kubernetes.io/instance: bitlybot
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: bitlybot-api
+  labels:
+    app.kubernetes.io/name: bitlybot-api
+    app.kubernetes.io/instance: bitlybot
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: bitlybot-api
+spec:
+  backend:
+    serviceName: bitlybot-api
+    servicePort: 8080
+

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,14 @@
+apiVersion: skaffold/v2alpha1
+kind: Config
+metadata:
+  name: bitlybot
+build:
+  artifacts:
+  - image: jharshman/bitlybot
+    context: .
+    docker:
+      dockerfile: build-tools/res/Dockerfile
+deploy:
+  kubectl:
+    manifests:
+    - build-tools/res/manifest.yaml


### PR DESCRIPTION
Setup Docker multistage build & modify Makefile.
Create a `build-tools/res` directory to house the Dockerfile and K8S manifest YAML.
Add Skaffold configuration.

`make publish` will run skaffold which will trigger the multistage Docker build and publish the container image.  Right now it's set to `jharshman/bitlybot` but @OscarLuu should create your own DockerHub account so it can be published there instead.

The Kubernetes Manifest `manifest.yaml` is WIP.  Some items need to be addressed in the app code.
* Health check
* Readiness check

Then need to switch Service Type from NodePort to LoadBalancer.