### PR TITLE
regex: update regex to be smarter with links

### DIFF
--- a/pkg/handler/main.go
+++ b/pkg/handler/main.go
@@ -20,9 +20,12 @@ func OnMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	// Instead of searching for anything that starts with ^http
 	// we should parse the link out of m.Content
-	re := regexp.MustCompile(`^http*\.*`)
+	// blah bit.ly blah
+	re := regexp.MustCompile(`http([^\s]+)`)
 	if re.MatchString(m.Content) {
-		short, err := bitly.Shorten(m.Content)
+		link := re.FindString(m.Content)
+		log.Infof("%v", link)
+		short, err := bitly.Shorten(link)
 		log.Infof("creating short link %v", short)
 		if err != nil {
 			log.Errorf("creating short link %v", err)

--- a/pkg/handler/main.go
+++ b/pkg/handler/main.go
@@ -24,7 +24,6 @@ func OnMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	re := regexp.MustCompile(`http([^\s]+)`)
 	if re.MatchString(m.Content) {
 		link := re.FindString(m.Content)
-		log.Infof("%v", link)
 		short, err := bitly.Shorten(link)
 		log.Infof("creating short link %v", short)
 		if err != nil {

--- a/pkg/handler/main.go
+++ b/pkg/handler/main.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/OscarLuu/bitlybot/pkg/bitly"
 	"github.com/OscarLuu/bitlybot/pkg/scraper"
@@ -20,7 +21,6 @@ func OnMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	// Instead of searching for anything that starts with ^http
 	// we should parse the link out of m.Content
-	// blah bit.ly blah
 	re := regexp.MustCompile(`http([^\s]+)`)
 	if re.MatchString(m.Content) {
 		link := re.FindString(m.Content)
@@ -40,7 +40,8 @@ func OnMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 			// creating and sending the message
 			log.Infof("created short link %v", short)
-			shortAuthor := " - " + (string(m.Author.Username) + "\n\n" + scrape + "\n" + short)
+			message := strings.Replace(m.Content, link, short, 1)
+			shortAuthor := " - " + (string(m.Author.Username) + "\n" + scrape + "\n" + message)
 			s.ChannelMessageSend(m.ChannelID, shortAuthor)
 
 			// deleting the message


### PR DESCRIPTION
This PR updates the regex to be smarter so that it can find links anywhere in the chat message. Also, adds a way to preserve the additional text that a message may have. 